### PR TITLE
Alias command fixup

### DIFF
--- a/commands/command_funcs.go
+++ b/commands/command_funcs.go
@@ -138,6 +138,9 @@ func showHelpCommand(ctx context.Context, args []string) (*discordgo.MessageEmbe
 	// getting help about all commands
 	var allCommands []*discordgo.MessageEmbedField
 	for name, c := range commMap {
+		if _, isAlias := aliasMap[name]; isAlias {
+			continue
+		}
 		allCommands = append(allCommands, &discordgo.MessageEmbedField{
 			Name:  name,
 			Value: c.Help(),

--- a/commands/command_funcs_test.go
+++ b/commands/command_funcs_test.go
@@ -103,12 +103,29 @@ func TestShowHelpCommand_SingleCommand(t *testing.T) {
 }
 
 func TestShowHelpCommand_AllCommands(t *testing.T) {
+	testAliases := map[string]*alias{
+		"test-alias": &alias{Value: "testValue", Kind: kindOTHER},
+	}
+	cleanup, err := createSampleAliases(testAliases)
+	if err != nil {
+		t.Fatalf("Failed to create sample alias file: %s", err)
+	}
+	defer cleanup()
+
+	commMap, err := withAliasCommands(commMap)
+	if err != nil {
+		t.Fatalf("withAliasCommands: %s", err)
+	}
+
 	got, err := showHelpCommand(context.Background(), []string{"help"})
 	if err != nil {
 		t.Fatalf("showHelpCommand error: %s", err)
 	}
-	if len(got.Fields) != len(commMap) {
-		t.Errorf("Did not give help for all commands: %v", got.Fields)
+	// we ignore aliases in the help command
+	wantLen := len(commMap) - len(aliasMap)
+	gotLen := len(got.Fields)
+	if wantLen != gotLen {
+		t.Errorf("Did not give help for all commands: wanted %d; got %d", wantLen, gotLen)
 	}
 }
 


### PR DESCRIPTION
Changes:
- Fixed issue where the page numbers in the paginator were wrong
- Removed the aliases from the help command
- Added an alias kind to the alias storage so that we don't have to make an HTTP request for each alias when we create the paginator